### PR TITLE
add property `cursorColorEnabled`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ However, you can also change:
     "rgba(127,255,127,0.1)",
     "rgba(255,127,255,0.1)"
   ],
+  // Enable cursor column highlighting (default: true).
+  "markdownTableRainbow.cursorColorEnabled": true,
   // Cursor column color strings (hex, rgba, rgb).
   "markdownTableRainbow.cursorColor": "rgba(100,50,180,0.8)",
 ```

--- a/package.json
+++ b/package.json
@@ -41,6 +41,11 @@
                     ],
                     "description": "%markdownTableRainbow.colors%"
                 },
+                "markdownTableRainbow.cursorColorEnabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%markdownTableRainbow.cursorColorEnabled%"
+                },
                 "markdownTableRainbow.cursorColor": {
                     "type": "string",
                     "default": "rgba(100,50,180,0.8)",

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -2,6 +2,7 @@
     "markdownTableRainbow.description": "マークダウンのテーブルの各カラムに色を付けます。",
     "markdownTableRainbow.updateDelay": "カラムの色を更新するまでのミリ秒単位の遅延時間。",
     "markdownTableRainbow.colors": "各カラムの色文字列 (hex, rgba, rgb) の配列。",
+    "markdownTableRainbow.cursorColorEnabled": "カーソル列の強調表示を有効にする",
     "markdownTableRainbow.cursorColor": "カーソルのある列の色文字列 (hex, rgba, rgb).",
     "markdownTableRainbow.regexp.patternErrorMessage": "色コードは \"#RRGGBB\", \"rgb(R,G,B)\" または \"rgba(R,G,B,A)\" の形式で指定してください。"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,6 +2,7 @@
     "markdownTableRainbow.description": "Color each column of the markdown table.",
     "markdownTableRainbow.updateDelay": "Delay time in milliseconds before updating colors.",
     "markdownTableRainbow.colors": "An array of color strings (hex, rgba, rgb) for each column.",
+    "markdownTableRainbow.cursorColorEnabled": "Enable highlighting of the cursor column.",
     "markdownTableRainbow.cursorColor": "Cursor column color strings (hex, rgba, rgb).",
     "markdownTableRainbow.regexp.patternErrorMessage": "Specify the color string in \"#RRGGBB\", \"rgb(R,G,B)\" or \"rgba(R,G,B,A)\" format."
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,7 @@ export const activate = (context: vscode.ExtensionContext): void => {
 
   const decorationTypes: vscode.TextEditorDecorationType[] = [];
   let cursorDecoType: vscode.TextEditorDecorationType | undefined = undefined;
+  let isCursorColorEnabled = true;
   const createResources = (showError = false): void => {
     decorationTypes.forEach(it => dispose(it));
     decorationTypes.length = 0;
@@ -52,6 +53,7 @@ export const activate = (context: vscode.ExtensionContext): void => {
       dispose(cursorDecoType);
       cursorDecoType = undefined;
     }
+    isCursorColorEnabled = getConfig().get<boolean>('cursorColorEnabled', true);
     const cursorColor = getConfig().get<string>('cursorColor', 'rgba(100,50,180,0.8)');
     cursorDecoType = vscode.window.createTextEditorDecorationType({
       backgroundColor: cursorColor,
@@ -92,7 +94,7 @@ export const activate = (context: vscode.ExtensionContext): void => {
           editor.document.positionAt(startPos),
           editor.document.positionAt(startPos + matchColumn[0].length)
         );
-        if (index === cursorColumn) {
+        if (isCursorColorEnabled && index === cursorColumn) {
           cursorOpt.push({ range });
         } else {
           options[index % options.length].push({ range });


### PR DESCRIPTION
Add a property to allow turning off cursor column highlighting.

- Property Name: `markdownTableRainbow.cursorColorEnabled`
- If true, highlighting is enabled.
- Default value is true for compatibility.

fix #4