### PR TITLE
Upgrade to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 2025-03-06, 1.1.0 release
+
+- MDX file support
+- Added `markdownTableRainbow.cursorColorEnabled` flag
+
 ## 2023-04-29, 1.0.2 release
 
 - fix to determine if the cursor position is a table

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "markdown-table-rainbow",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "markdown-table-rainbow",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "license": "MIT",
             "dependencies": {
                 "@vscode/l10n": "^0.0.13"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "displayName": "markdown-table-rainbow",
     "description": "%markdownTableRainbow.description%",
     "publisher": "yoshi389111",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "license": "MIT",
     "l10n": "./l10n",
     "repository": {


### PR DESCRIPTION
## 2025-03-06, 1.1.0 release

- MDX file support
- Added `markdownTableRainbow.cursorColorEnabled` flag
