### PR TITLE
:lady_beetle: fix: npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2865,9 +2865,9 @@
             "license": "ISC"
         },
         "node_modules/markdown-it": {
-            "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+            "version": "14.1.1",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
```console
$ npm audit
# npm audit report

markdown-it  13.0.0 - 14.1.0
Severity: moderate
markdown-it is has a Regular Expression Denial of Service (ReDoS) - https://github.com/advisories/GHSA-38c4-r59v-3vqw
fix available via `npm audit fix`
node_modules/markdown-it

1 moderate severity vulnerability

To address all issues, run:
  npm audit fix
exited 1
$ npm audit fix

changed 1 package, and audited 365 packages in 2s

77 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```